### PR TITLE
Fixed typos and made examples work on UNIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ geometric entities (such as circles, squares and text) but always involves
 pixels eventually to display.  In most systems, the pixels are tucked away
 under levels of abstraction in the rendering system.  Abstract Rendering
 takes the opposite approach: expose the pixels and gain powerful pixel-level
-control.  This pixel-level power is a complement many existing visualization
+control.  This pixel-level power is a complement to many existing visualization
 techniques.  It is an elaboration on rendering, not an analytic or projection step,
 so it can be used as epilogue to many existing techniques.
 
@@ -22,7 +22,7 @@ represented on that image's discrete pixels.  The source space is a
 canvas that contains logically continuous geometric primitives 
 and the target space is an image that contains discrete colors.
 Abstract Rendering fits between these two states.  It introduces
-a discretization of the data at the pixel-level, but not necessarily all
+a discretization of the data at the pixel level, but not necessarily all
 the way to colors.  This enables many pixel-level concerns to be efficiently 
 and concisely captured.
 

--- a/java/README.md
+++ b/java/README.md
@@ -21,13 +21,13 @@ The simplest application is titled "SimpleApp." It is executed with
 The source code (found in app/ar/SimpleApp.jar) provides documented example of how
 to use Abstract Rendering through the provided swing panel or to produce images directly.
 
-For a more interactive demo, run "java -cp ARApp.jar:AR.jar:lib/* ar.app.ARApp".
+For a more interactive demo, run 'java -cp "ARApp.jar:AR.jar:lib/*" ar.app.ARApp'.
 This application presents a number of preset datasets/treatments in the drop-down box.
 Shifting between datasets results in a full rendering, but only shifting
 between a treatments results in partial re-rendering (just 
 re-executing the transfer function).
 
-For a more full-featured application execute "java -cp ARApp.jar:AR.jar:lib/* ar.app.ARApp -ext".
+For a more full-featured application execute 'java -cp "ARApp.jar:AR.jar:lib/*" ar.app.ARApp -ext'.
 This application allows exploration of your own data and various treatments.
 However, there are combinations that will not work (for example, glyph-parallel 
 rendering requires a list-based glyph container type).  No effort is made to 
@@ -56,13 +56,13 @@ are supported as aggregate types). Avro can be used to serialize to binary or to
 ### Seam Carving
 Image retargeting based on [seam-carving](http://en.wikipedia.org/wiki/Seam_carving).
 
-### Sever
+### Server
 The ARServer is a self-contained HTTP server that responds to post messages that describe
-a dataset and treatment.  It returns json-encoded aggregates that result 
-If the AR.jar file was built with extensions, the server can be executed with
-"java -jar AR.jar ar.ext.server.ARServer" paramters are -host and -port 
-(which default to "localhost" and "8080," respectively).  The sever uses the Avro extensions
-to format the return result.
+a dataset and treatment.  It returns json-encoded aggregates that result. Using an ARext.jar
+file built using "ant fetch-ext ext" to get the extensions, the server can be executed with
+"java -jar ARext.jar ar.ext.server.ARServer".  Parameters are -host and -port 
+(which default to "localhost" and "8080," respectively).  The server uses the Avro extensions
+to format the returned result.
 
 ### Spark
 Abstract Rendering implementation to run in the [AMP Spark](http://spark-project.org/) framework.
@@ -70,12 +70,12 @@ This uses many of the standard tools, but different driver (e.g., not true "Rend
 to do aggregation in a distributed memory environment.  Transfer is still done locally.
 
 Because there are many Spark-specific dependencies, they are acquired with "ant fetch-spark".
-Run with "java -cp ./*:lib/* ar.ext.spark.SimpleSparkApp" for a basic demo.  For access to
-other demos, use "java -cp ./*:lib/* ar.ext.spark.SparkDemoApp" and related options.
+Run with 'java -cp "./*:lib/*" ar.ext.spark.SimpleSparkApp' for a basic demo.  For access to
+other demos, use 'java -cp "./*:lib/*" ar.ext.spark.SparkDemoApp' and related options.
  
 ### Tiles
 Tools for manipulating aggregates for use with a tile-server.
 Can create tiles from aggregates or combine multiple tiles into an aggregate set.
-RElies on the Avro extension.
+Relies on the Avro extension.
 
 

--- a/java/ext/ar/ext/server/ARCombiner.java
+++ b/java/ext/ar/ext/server/ARCombiner.java
@@ -31,7 +31,7 @@ import ar.glyphsets.implicitgeometry.Valuer;
  * When a new aggregate arrives, listeners can be notified.  Alternatively, polling can 
  * be achieved by monitoring the "count" method's value. 
  * 
- * This is NOT a compliment to the ARServer.  The ARServer is a REST application that expects incoming
+ * This is NOT a complement to the ARServer.  The ARServer is a REST application that expects incoming
  * socket connections.  Use the ar.ext.avro.AggregateSerializer.deserialize methods to handle
  * the results returned from ARServer.
  * 


### PR DESCRIPTION
This is partially just to do an example pull request for this project, but also to make the examples be able to be cut and pasted into a UNIX terminal and have them work.  I *think* they will still work on windows (assuming Windows ignores double quotes), but it's worth checking.  I've also changed the description of how to invoke the Java server version, which should be checked for accuracy.